### PR TITLE
Increase upload size to 2GB

### DIFF
--- a/LocalFileTransferSystem.py
+++ b/LocalFileTransferSystem.py
@@ -22,8 +22,8 @@ app = Flask(__name__)
 BASE_DIR = os.path.abspath("shared_files")
 os.makedirs(BASE_DIR, exist_ok=True)
 
-# Optional: Increase max upload size to 100 MB
-app.config['MAX_CONTENT_LENGTH'] = 100 * 1024 * 1024
+# Optional: Increase max upload size to 2000 MB
+app.config['MAX_CONTENT_LENGTH'] = 2000 * 1024 * 1024
 
 def safe_path(path=""):
     full_path = os.path.abspath(os.path.join(BASE_DIR, path))

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ A simple **local network file sharing and management system** built with Flask. 
 - Create, rename, and delete files and folders  
 - Responsive and mobile-friendly design  
 - Secure path handling to prevent directory traversal  
-- Customizable max upload size (default 100MB)  
+- Customizable max upload size (default 2000MB)  
 - Minimal terminal output for clean startup  
 - Custom terminal banner (with fallback for executable builds)  
 


### PR DESCRIPTION
modern browsers can manage to upload 2GB files. Thus having the limit set to 100MB doesn't make sense. People will mostly use it in their local environment where download/upload speeds doesn't matter that much and storage capacity doesn't matter either. It's unlikely that someone try to abuse it but uploading many large files because only trusted devices should be connected to in a local environment. I see no reason to have the limit at 100MB...